### PR TITLE
Only distribute necessary files on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "devDependencies": {
     "mocha": "*",
     "should": "*"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Only the `index.js` file needs to be distributed with npm (tests and other files do not need to be) so this change will reduce the size of the npm distribution.
