### PR TITLE
added support for Symbol-keyed object properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,6 +61,8 @@ function isEmpty(val) {
           if (has.call(val, key)) return false
         }
 
+        if (Object.getOwnPropertySymbols && Object.getOwnPropertySymbols(val).length > 0) return false
+
         return true
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ describe('is-empty', function () {
     assert(empty({}) == true)
     assert(empty({ a: 'b' }) == false)
     assert(empty({ length: 0 }) == false)
+    assert(empty({ [Symbol()]: 1 }) == false)
   })
 
   it('handles strings', function () {


### PR DESCRIPTION
ES2015 introduces Symbols which can be used as object keys. These keys are visible neither to for-in nor to Object.keys(), and the only way to find them is by using Object.getOwnPropertySymbols().

This pull request adds support for detecting Symbol-keyed object properties.